### PR TITLE
1-Fix sass syntanx error

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -316,11 +316,6 @@ section.success a.active {
     transition: top .3s ease,opacity .3s ease;
 }
 
-.floating-label-form-group::not(:first-child) {
-    padding-left: 14px;
-    border-left: 1px solid #eee;
-}
-
 .floating-label-form-group-with-value label {
     top: 0;
     opacity: 1;


### PR DESCRIPTION
Issue #1 

### Note:
I couldn't deploy the application due sass syntax error in the `custom.css.scss` file which caused the rake command for Precompiling assets to fail hence rake aborted! and Push rejected, failed to compile Ruby app. This PR fixes that

### Task Involved:
- [x] Remove the sass unrecognised css rules from `custom.css.scss` file

### Heroku Logs:
```
-----> Ruby app detected
-----> Compiling Ruby/Rails
-----> Using Ruby version: ruby-2.0.0
-----> Installing dependencies using bundler 1.9.7
       Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
       Rubygems 2.0.14 is not threadsafe, so your gems must be installed one at a time. Upgrade to Rubygems 2.1.0 or higher to enable parallel gem installation.
       Installing rake 10.4.2
       Installing i18n 0.7.0
       Installing json 1.8.3
       Installing minitest 5.8.0
       Installing thread_safe 0.3.5
       Installing tzinfo 1.2.2
       Installing activesupport 4.2.3
       Installing builder 3.2.2
       Installing erubis 2.7.0
       Installing mini_portile 0.6.2
       Installing nokogiri 1.6.6.2
       Installing rails-deprecated_sanitizer 1.0.3
       Installing rails-dom-testing 1.0.7
       Installing loofah 2.0.3
       Installing rails-html-sanitizer 1.0.2
       Installing actionview 4.2.3
       Installing rack 1.6.4
       Installing rack-test 0.6.3
       Installing actionpack 4.2.3
       Installing globalid 0.3.6
       Installing activejob 4.2.3
       Installing mime-types 2.6.2
       Installing mail 2.6.3
       Installing actionmailer 4.2.3
       Installing activemodel 4.2.3
       Installing arel 6.0.3
       Installing activerecord 4.2.3
       Installing coffee-script-source 1.9.1.1
       Installing execjs 2.6.0
       Installing coffee-script 2.4.1
       Installing thor 0.19.1
       Installing railties 4.2.3
       Installing coffee-rails 4.1.0
       Installing multi_json 1.11.2
       Installing jbuilder 2.3.1
       Installing jquery-rails 4.0.5
       Installing pg 0.18.3
       Using bundler 1.9.7
       Installing sprockets 3.3.4
       Installing sprockets-rails 2.3.3
       Installing rails 4.2.3
       Installing rdoc 4.2.0
       Installing sass 3.4.18
       Installing tilt 2.0.1
       Installing sass-rails 5.0.4
       Installing sdoc 0.4.1
       Installing turbolinks 2.5.3
       Installing uglifier 2.7.2
       Bundle complete! 12 Gemfile dependencies, 48 gems now installed.
       Gems in the groups development and test were not installed.
       Bundled gems are installed into ./vendor/bundle.
       Post-install message from rdoc:
       Depending on your version of ruby, you may need to install ruby rdoc/ri data:
       <= 1.8.6 : unsupported
       = 1.8.7 : gem install rdoc-data; rdoc-data --install
       = 1.9.1 : gem install rdoc-data; rdoc-data --install
       >= 1.9.2 : nothing to do! Yay!
       Bundle completed (19.50s)
       Cleaning up the bundler cache.
-----> Preparing app for Rails asset pipeline
       Running: rake assets:precompile
       I, [2015-10-23T05:22:38.292017 #1007]  INFO -- : Writing /tmp/build_bc10ceca23d59af9d312c87d27d2560/public/assets/3sixd-554f90df57b9da9a9f650e9b024ebf9ee673dab26dd741ecb63491cfcb333558.png
       rake aborted!
       Sass::SyntaxError: Invalid CSS after "...orm-group::not(": expected pseudo_expr, was ":first-child)
       sass):320
       /tmp/build_bc10ceca23d59af9d312c187d27d2560/vendor/bundle/ruby/2.0.0/gems/sass-3.4.18/lib/sass/scss/parser.rb:1162:in `expected'
       Tasks: TOP => assets:precompile
       (See full trace by running task with --trace)
 !     Precompiling assets failed.
 !     Push rejected, failed to compile Ruby app
```