### PR TITLE
12-Remove authentication to non admin users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,4 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-
-  before_action :authenticate_user!
 end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,4 +1,6 @@
 class CompaniesController < ApplicationController
+  before_action :authenticate_user!
+  
   def new
     @company = Company.new
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -34,22 +34,24 @@
         <li class="page-scroll">
           <a href="#contact">Contact</a>
         </li>
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown">Settings
-            <span class="caret"></span>
-          </a>
-          <ul class="dropdown-menu">
-            <li>
-              <%= link_to 'Add company', new_company_path %>
-            </li>
-            <li>
-              <%= link_to 'Customize company', companies_path %>
-            </li>
-            <li>
-              <%= link_to 'Sign out', destroy_user_session_path, :method => :delete %>
-            </li>
-          </ul>
-        </li>
+        <% if signed_in? %>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Settings
+              <span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu">
+              <li>
+                <%= link_to 'Add company', new_company_path %>
+              </li>
+              <li>
+                <%= link_to 'Customize company', companies_path %>
+              </li>
+              <li>
+                <%= link_to 'Sign out', destroy_user_session_path, :method => :delete %>
+              </li>
+            </ul>
+          </li>
+        <% end %>
       </ul>
     </div>
     <!-- /.navbar-collapse -->

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -34,7 +34,7 @@
         <li class="page-scroll">
           <a href="#contact">Contact</a>
         </li>
-        <% if signed_in? %>
+        <% if user_signed_in? %>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Settings
               <span class="caret"></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'jobs#index'
-  resources :companies
+
+  authenticate :user do
+    scope "/admin" do
+      resources :companies
+    end
+  end
 end


### PR DESCRIPTION
Issue #12 

## Note:
Most of the users to this site but the recruiter are just the normal non admin users who are not supposed to sign in in order to use the site so this issue will take care of that by adding the authentication **only** to those who needs to be authenticated like the recruiter/admin

## Story:
**AS A Non Admin User** of the site
**I WANT TO** be able to see the job openings, upload my CV and do all of the recruitment stuffs without having to sign up / sign in to the site
**SO THAT** I can skip all the harder part for having to sign in every time I want to use the site

## Acceptance Criteria:
- [x] GIVEN I am the non-admin user and wants to use the site WHEN I access the 3sixd link THEN I SHOULD be able to be landed to its home page WITHOUT having to sign in / sign up
- [x] GIVEN I am the admin user and want to add a company or customize a company THEN I SHOULD be able to do so WHEN I successfully sign on to the site