### PR TITLE
24-Remove the unneeded content from the home view

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -57,7 +57,7 @@ class CompaniesController < ApplicationController
 
   def company_params
     params.require(:company).permit(:name, :title, :description, :about, :address1, :address2, :city, 
-      :state_id, :zip, :facebook, :google_plus, :twitter, :linkedin, :dribble, :logo, :logo_cache, 
+      :state_id, :zip, :facebook, :google_plus, :twitter, :linkedin, :logo, :logo_cache, 
       :intro_image, :intro_image_cache, :css, :css_cache)
   end
 end

--- a/app/views/companies/_edit_form.html.erb
+++ b/app/views/companies/_edit_form.html.erb
@@ -52,14 +52,14 @@
       <%= f.text_field :twitter, class: "form-control" %>
     </div>
   </div>
-  <div class="form-group"> 
-    <%= f.label :dribble, "Dribble account:", class: "col-md-2 control-label" %>
-    <div class="col-md-4">
-      <%= f.text_field :dribble, class: "form-control" %>
-    </div>
+  <div class="form-group">
     <%= f.label :linkedin, "Linkedin account:", class: "col-md-2 control-label" %>
     <div class="col-md-4">
       <%= f.text_field :linkedin, class: "form-control" %>
+    </div>
+    <%= f.label :about, "Company about:", class: "col-md-2 control-label" %>
+    <div class="col-md-4">
+      <%= f.text_area :about, required: true, class: "form-control" %>
     </div>
   </div>
   <div class="form-group"> 
@@ -67,9 +67,10 @@
     <div class="col-md-4">
       <%= f.text_area :description, required: true, class: "form-control" %>
     </div>
-    <%= f.label :about, "Company about:", class: "col-md-2 control-label" %>
-    <div class="col-md-4">
-      <%= f.text_area :about, required: true, class: "form-control" %>
+    <%= f.label :css, "Custom CSS:", class: "col-md-2 control-label" %>
+    <div class="col-md-4">    
+      <%= f.file_field :css %>
+      <%= f.hidden_field :css_cache %>
     </div>
   </div>
   <div class="form-group"> 
@@ -82,13 +83,6 @@
     <div class="col-md-4">    
       <%= f.file_field :intro_image %>
       <%= f.hidden_field :intro_image_cache %>
-    </div>
-  </div>
-  <div class="form-group"> 
-    <%= f.label :css, "Custom CSS:", class: "col-md-2 control-label" %>
-    <div class="col-md-4">    
-      <%= f.file_field :css %>
-      <%= f.hidden_field :css_cache %>
     </div>
   </div>
   <div class="form-group">

--- a/app/views/companies/_form.html.erb
+++ b/app/views/companies/_form.html.erb
@@ -57,15 +57,16 @@
       <%= f.text_field :twitter, class: "form-control", placeholder: "https://twitter.com/palmer" %>
     </div>
   </div>
-  <div class="form-group"> 
-    <%= f.label :dribble, "Dribble account:", class: "col-md-2 control-label" %>
-    <div class="col-md-4">
-      <%= f.text_field :dribble, class: "form-control", placeholder: "https://dribbble.com/palmer" %>
-    </div>
+  <div class="form-group">
     <%= f.label :linkedin, "Linkedin account:", class: "col-md-2 control-label" %>
     <div class="col-md-4">
       <%= f.text_field :linkedin, class: "form-control", 
         placeholder: "https://www.linkedin.com/palmer" %>
+    </div>
+    <%= f.label :about, "Company about:", class: "col-md-2 control-label" %>
+    <div class="col-md-4">
+      <%= f.text_area :about, required: true, class: "form-control",
+        placeholder: "Palmer Tech is one of the best leading tech companies in USA with over 500 millions of customers worldwide, one of the best place to explore tech" %>
     </div>
   </div>
   <div class="form-group"> 
@@ -74,10 +75,10 @@
       <%= f.text_area :description, required: true, class: "form-control", 
         placeholder: "Best Technologies Choices - With best products - For better life" %>
     </div>
-    <%= f.label :about, "Company about:", class: "col-md-2 control-label" %>
-    <div class="col-md-4">
-      <%= f.text_area :about, required: true, class: "form-control",
-        placeholder: "Palmer Tech is one of the best leading tech companies in USA with over 500 millions of customers worldwide, one of the best place to explore tech" %>
+    <%= f.label :css, "Custom CSS:", class: "col-md-2 control-label" %>
+    <div class="col-md-4">    
+      <%= f.file_field :css %>
+      <%= f.hidden_field :css_cache %>
     </div>
   </div>
   <div class="form-group"> 
@@ -90,13 +91,6 @@
     <div class="col-md-4">    
       <%= f.file_field :intro_image %>
       <%= f.hidden_field :intro_image_cache %>
-    </div>
-  </div>
-  <div class="form-group"> 
-    <%= f.label :css, "Custom CSS:", class: "col-md-2 control-label" %>
-    <div class="col-md-4">    
-      <%= f.file_field :css %>
-      <%= f.hidden_field :css_cache %>
     </div>
   </div>
   <div class="form-group">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -128,21 +128,6 @@
                                 </a>
                               <% end %>
                             </li>
-                            <li>
-                              <% if current_page?(companies_path) %>
-                                <a href="<%= @default_company.dribble %>" class="btn-social btn-outline"
-                                  target="_blank"><i class="fa fa-fw fa-dribbble"></i>
-                                </a>
-                              <% elsif current_page?(new_company_path) %>
-                                <a href="#" class="btn-social btn-outline">
-                                  <i class="fa fa-fw fa-dribbble"></i>
-                                </a>
-                              <% elsif @company.present? && !(current_page?(new_company_path)) %>
-                                <a href="<%= @company.dribble %>" class="btn-social btn-outline"
-                                  target="_blank"><i class="fa fa-fw fa-dribbble"></i>
-                                </a>
-                              <% end %>
-                            </li>
                         </ul>
                     </div>
                     <div class="footer-col col-md-4">

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -172,11 +172,6 @@
                                 target="_blank"><i class="fa fa-fw fa-linkedin"></i>
                               </a>
                             </li>
-                            <li>
-                              <a href="<%= @company.dribble %>" class="btn-social btn-outline" 
-                                target="_blank"><i class="fa fa-fw fa-dribbble"></i>
-                              </a>
-                            </li>
                         </ul>
                     </div>
                     <div class="footer-col col-md-4">

--- a/db/migrate/20151222073609_remove_dribble_from_companies.rb
+++ b/db/migrate/20151222073609_remove_dribble_from_companies.rb
@@ -1,0 +1,5 @@
+class RemoveDribbleFromCompanies < ActiveRecord::Migration
+  def change
+    remove_column :companies, :dribble, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151214060428) do
+ActiveRecord::Schema.define(version: 20151222073609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,7 +24,6 @@ ActiveRecord::Schema.define(version: 20151214060428) do
     t.string   "google_plus"
     t.string   "twitter"
     t.string   "linkedin"
-    t.string   "dribble"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.string   "title"

--- a/db/seeds/companies.rb
+++ b/db/seeds/companies.rb
@@ -9,7 +9,7 @@ Company.create!([
     posted.", address1: "700 Craighead St", address2: "Suite 106", city: "Nashville", 
     state_id: State.find_by_code('TN').id, zip: "37204", facebook: "https://facebook.com", 
     twitter: "https://twitter.com", google_plus: "https://plus.google.com", 
-    linkedin: "https://www.linkedin.com", dribble: "https://dribbble.com", default: 'true'
+    linkedin: "https://www.linkedin.com", default: 'true'
   },
   { 
     name: "Furaha", title: "Furaha Software Inc,",
@@ -20,6 +20,6 @@ Company.create!([
     address1: "701 Craighead St", address2: "Suite 107", city: "Nashville", 
     state_id: State.find_by_code('IL').id, zip: "37207", facebook: "https://facebook.com", 
     twitter: "https://twitter.com", google_plus: "https://plus.google.com", 
-    linkedin: "https://www.linkedin.com", dribble: "https://dribbble.com", default: 'false'
+    linkedin: "https://www.linkedin.com", default: 'false'
   }
 ])

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -14,7 +14,6 @@
   google_plus: https://plus.google.com
   twitter: https://twitter.com
   linkedin: https://www.linkedin.com
-  dribble: https://dribble.com
   logo: 3sixd.png
   default: 'true'
 
@@ -32,6 +31,5 @@ Furaha:
   google_plus: https://plus.google.com
   twitter: https://twitter.com
   linkedin: https://www.linkedin.com
-  dribble: https://dribble.com
   logo: furaha.png
   default: 'false'

--- a/test/models/company_test.rb
+++ b/test/models/company_test.rb
@@ -42,7 +42,4 @@ class CompanyTest < ActiveSupport::TestCase
   test 'has linkedin account link' do
     assert_equal 'https://www.linkedin.com', @company.linkedin
   end
-  test 'has dribble account link' do
-    assert_equal 'https://dribble.com', @company.dribble
-  end
 end


### PR DESCRIPTION
Issue #24 

### Note:
Before we had `dribbble` as part of the social networking icon but now it is not needed any more so this PR removes that

### Story:
AS A User of the site
I WANT TO see only the most and important useful contents on the views
SO THAT I am not confused with extra unneeded contents

### Acceptance Criteria:
- [x] GIVEN I am the user accessing the site WHEN I interact with the site's views THEN I should only see the useful contents of the core site main functionalities