### PR TITLE
24-Make footer about contents editable

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -58,6 +58,6 @@ class CompaniesController < ApplicationController
   def company_params
     params.require(:company).permit(:name, :title, :description, :about, :address1, :address2, :city, 
       :state_id, :zip, :facebook, :google_plus, :twitter, :linkedin, :logo, :logo_cache, 
-      :intro_image, :intro_image_cache, :css, :css_cache)
+      :intro_image, :intro_image_cache, :css, :css_cache, :footer_about)
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -7,6 +7,7 @@ class Company < ActiveRecord::Base
   validates :title,       presence: true
   validates :description, presence: true
   validates :about,       presence: true
+  validates :footer_about, presence: true
   validates :address1,    presence: true
   validates :city,        presence: true
   validates :zip,         presence: true, length: { is: 5 }

--- a/app/views/companies/_edit_form.html.erb
+++ b/app/views/companies/_edit_form.html.erb
@@ -67,10 +67,9 @@
     <div class="col-md-4">
       <%= f.text_area :description, required: true, class: "form-control" %>
     </div>
-    <%= f.label :css, "Custom CSS:", class: "col-md-2 control-label" %>
-    <div class="col-md-4">    
-      <%= f.file_field :css %>
-      <%= f.hidden_field :css_cache %>
+    <%= f.label :footer_about, "Footer about:", class: "col-md-2 control-label" %>
+    <div class="col-md-4">
+      <%= f.text_area :footer_about, required: true, class: "form-control" %>
     </div>
   </div>
   <div class="form-group"> 
@@ -83,6 +82,13 @@
     <div class="col-md-4">    
       <%= f.file_field :intro_image %>
       <%= f.hidden_field :intro_image_cache %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= f.label :css, "Custom CSS:", class: "col-md-2 control-label" %>
+    <div class="col-md-4">    
+      <%= f.file_field :css %>
+      <%= f.hidden_field :css_cache %>
     </div>
   </div>
   <div class="form-group">

--- a/app/views/companies/_form.html.erb
+++ b/app/views/companies/_form.html.erb
@@ -75,10 +75,10 @@
       <%= f.text_area :description, required: true, class: "form-control", 
         placeholder: "Best Technologies Choices - With best products - For better life" %>
     </div>
-    <%= f.label :css, "Custom CSS:", class: "col-md-2 control-label" %>
-    <div class="col-md-4">    
-      <%= f.file_field :css %>
-      <%= f.hidden_field :css_cache %>
+    <%= f.label :footer_about, "Footer about:", class: "col-md-2 control-label" %>
+    <div class="col-md-4">
+      <%= f.text_area :footer_about, required: true, class: "form-control", 
+        placeholder: "3sixD posts jobs for the positions which they are currently hiring" %>
     </div>
   </div>
   <div class="form-group"> 
@@ -91,6 +91,13 @@
     <div class="col-md-4">    
       <%= f.file_field :intro_image %>
       <%= f.hidden_field :intro_image_cache %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= f.label :css, "Custom CSS:", class: "col-md-2 control-label" %>
+    <div class="col-md-4">    
+      <%= f.file_field :css %>
+      <%= f.hidden_field :css_cache %>
     </div>
   </div>
   <div class="form-group">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -131,8 +131,18 @@
                         </ul>
                     </div>
                     <div class="footer-col col-md-4">
-                      <h3>About 3sixD</h3>
-                      <p>3sixD posts jobs for the positions which they are currently hiring for and you can apply to the ones that interest you</p>
+                      <% if current_page?(companies_path) %>
+                        <h3>About <%= @default_company.name %></h3>
+                        <p><%= @default_company.footer_about %></p>
+                      <% elsif current_page?(new_company_path) %>
+                        <h3>About Company</h3>
+                        <p>
+                          Tell us more about your company by providing the details on the field footer about from the company's form
+                        </p>
+                      <% elsif @company.present? && !(current_page?(new_company_path)) %>
+                        <h3>About <%= @company.name %></h3>
+                        <p><%= @company.footer_about %></p>
+                      <% end %>
                     </div>
                 </div>
             </div>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -176,7 +176,7 @@
                     </div>
                     <div class="footer-col col-md-4">
                       <h3>About 3sixD</h3>
-                      <p>3sixD posts jobs for the positions which they are currently hiring for and you can apply to the ones that interest you</p>
+                      <p><%= @company.footer_about %></p>
                     </div>
                 </div>
             </div>

--- a/db/migrate/20151223044510_add_footer_about_to_company.rb
+++ b/db/migrate/20151223044510_add_footer_about_to_company.rb
@@ -1,0 +1,5 @@
+class AddFooterAboutToCompany < ActiveRecord::Migration
+  def change
+    add_column :companies, :footer_about, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151222073609) do
+ActiveRecord::Schema.define(version: 20151223044510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,8 +24,8 @@ ActiveRecord::Schema.define(version: 20151222073609) do
     t.string   "google_plus"
     t.string   "twitter"
     t.string   "linkedin"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
     t.string   "title"
     t.string   "logo"
     t.string   "intro_image"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20151222073609) do
     t.string   "zip"
     t.integer  "state_id"
     t.string   "css"
+    t.string   "footer_about"
   end
 
   create_table "states", force: :cascade do |t|

--- a/db/seeds/companies.rb
+++ b/db/seeds/companies.rb
@@ -9,7 +9,9 @@ Company.create!([
     posted.", address1: "700 Craighead St", address2: "Suite 106", city: "Nashville", 
     state_id: State.find_by_code('TN').id, zip: "37204", facebook: "https://facebook.com", 
     twitter: "https://twitter.com", google_plus: "https://plus.google.com", 
-    linkedin: "https://www.linkedin.com", default: 'true'
+    linkedin: "https://www.linkedin.com", default: 'true',
+    footer_about: "3sixD posts jobs for the positions which they are currently hiring for and you can 
+    apply to the ones that interest you"
   },
   { 
     name: "Furaha", title: "Furaha Software Inc,",
@@ -20,6 +22,6 @@ Company.create!([
     address1: "701 Craighead St", address2: "Suite 107", city: "Nashville", 
     state_id: State.find_by_code('IL').id, zip: "37207", facebook: "https://facebook.com", 
     twitter: "https://twitter.com", google_plus: "https://plus.google.com", 
-    linkedin: "https://www.linkedin.com", default: 'false'
+    linkedin: "https://www.linkedin.com", default: 'false', footer_about: "Furaha makes softwares for your needs"
   }
 ])

--- a/test/controllers/companies_controller_test.rb
+++ b/test/controllers/companies_controller_test.rb
@@ -79,7 +79,8 @@ class CompaniesControllerTest < ActionController::TestCase
     { name: "3sixd", title: '3sixd Consulting', description: 'Upload Cvs - Get hired', 
       about: '3sixD posts jobs for the positions which they are currently hiring for and 
       you can apply to the ones that interest you', address1: '701 Craighead St', address2: 'Suite 107',
-      city: 'Nashville', state_id: 1, zip: '37207', logo: "3six.png", css: "customtheme.css" }
+      city: 'Nashville', state_id: 1, zip: '37207', logo: "3six.png", css: "customtheme.css", 
+      footer_about: 'Furaha makes softwares for your needs' }
   end
 
   test "is valid with valid company params" do
@@ -99,6 +100,13 @@ class CompaniesControllerTest < ActionController::TestCase
     company = Company.new valid_company_params
     valid_company_params.delete :about
     assert company.errors[:about], "Missing error when without company about"
+  end
+
+  test "is invalid without company footer about" do
+    # Delete footer about before assert company is called
+    company = Company.new valid_company_params
+    valid_company_params.delete :footer_about
+    assert company.errors[:footer_about], "Missing error when without footer about"
   end
 
   test "is invalid without company address" do

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -16,6 +16,7 @@
   linkedin: https://www.linkedin.com
   logo: 3sixd.png
   default: 'true'
+  footer_about: 3sixD posts jobs for the positions which they are currently hiring for and you can apply to the ones that interest you
 
 Furaha:
   name: Furaha
@@ -33,3 +34,4 @@ Furaha:
   linkedin: https://www.linkedin.com
   logo: furaha.png
   default: 'false'
+  footer_about: Furaha makes softwares for your needs

--- a/test/models/company_test.rb
+++ b/test/models/company_test.rb
@@ -42,4 +42,7 @@ class CompanyTest < ActiveSupport::TestCase
   test 'has linkedin account link' do
     assert_equal 'https://www.linkedin.com', @company.linkedin
   end
+  test 'has footer about' do
+    assert_equal 'Furaha makes softwares for your needs', @company.footer_about
+  end
 end


### PR DESCRIPTION
Issue #24 

### Story:
AS AN Admin of the site
I WANT to update the site's contents including the footer about
SO THAT I can track the relevant information concerning the company

### Note:
The about contents at the right hand side of the site's footer is supposed to be editable so that the admin can add his own about contents, This PR takes care of that

### Acceptance Criteria:
- [x] GIVEN I am the site's admin WHEN I update my company's info THEN I should be able to update the footer about as well