### PR TITLE
24-Avoid forcing company title to uppercase

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -96,10 +96,10 @@ header img {
 }
 
 header .intro-text .name {
-    display: block;
-    font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
-    font-size: 2em;
-    font-weight: 700;
+  display: block;
+  font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size: 2em;
+  font-weight: 700;
 }
 
 header .intro-text .skills {

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -97,7 +97,6 @@ header img {
 
 header .intro-text .name {
     display: block;
-    text-transform: uppercase;
     font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
     font-size: 2em;
     font-weight: 700;
@@ -148,9 +147,8 @@ header .intro-text .skills {
 }
 
 .navbar {
-    text-transform: uppercase;
-    font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
-    font-weight: 700;
+  font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-weight: 700;
 }
 
 .navbar a:focus {


### PR DESCRIPTION
Issue #24 

### Story:
AS AN Admin of the site
I WANT to display the site's contents as I entered them when creating a company
SO THAT I can have the sites look intended for the users

### Note:
The company title was forced to be displayed in capital letters even when the admin entered it in small letters, This PR takes care of that by making sure the name will be displayed as entered

### Acceptance Criteria:
- [x] GIVEN I am the site's admin WHEN I enter the company title during adding a new company or updating an existing one THEN I should be see that title the way I entered it